### PR TITLE
support Global exception for NotFound and Operational Sqlalchemy Error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requires = [
     'zope.sqlalchemy',
     'alembic',
     # API
-    'hapic',
+    'hapic>=0.40',
     'marshmallow <3.0.0a1,>2.0.0',
     # CLI
     'cliff',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requires = [
     'zope.sqlalchemy',
     'alembic',
     # API
-    'hapic>=0.40',
+    'hapic>=0.41',
     'marshmallow <3.0.0a1,>2.0.0',
     # CLI
     'cliff',

--- a/tracim/__init__.py
+++ b/tracim/__init__.py
@@ -58,6 +58,7 @@ def main(global_config, **settings):
     hapic.set_context(context)
     context.handle_exception(NotFound, 404)
     context.handle_exception(OperationalError, 500)
+    context.handle_exception(Exception, 500)
     # Add controllers
     session_api = SessionController()
     configurator.include(session_api.bind, route_prefix=BASE_API_V2)

--- a/tracim/__init__.py
+++ b/tracim/__init__.py
@@ -5,6 +5,8 @@ import time
 from pyramid.config import Configurator
 from pyramid.authentication import BasicAuthAuthenticationPolicy
 from hapic.ext.pyramid import PyramidContext
+from pyramid.exceptions import NotFound
+from sqlalchemy.exc import OperationalError
 
 from tracim.extensions import hapic
 from tracim.config import CFG
@@ -49,12 +51,13 @@ def main(global_config, **settings):
     # Add SqlAlchemy DB
     configurator.include('.models')
     # set Hapic
-    hapic.set_context(
-        PyramidContext(
-            configurator=configurator,
-            default_error_builder=ErrorSchema()
-        )
+    context = PyramidContext(
+        configurator=configurator,
+        default_error_builder=ErrorSchema()
     )
+    hapic.set_context(context)
+    context.handle_exception(NotFound, 404)
+    context.handle_exception(OperationalError, 500)
     # Add controllers
     session_api = SessionController()
     configurator.include(session_api.bind, route_prefix=BASE_API_V2)

--- a/tracim/__init__.py
+++ b/tracim/__init__.py
@@ -53,7 +53,8 @@ def main(global_config, **settings):
     # set Hapic
     context = PyramidContext(
         configurator=configurator,
-        default_error_builder=ErrorSchema()
+        default_error_builder=ErrorSchema(),
+        debug=app_config.DEBUG,
     )
     hapic.set_context(context)
     context.handle_exception(NotFound, 404)

--- a/tracim/config.py
+++ b/tracim/config.py
@@ -128,6 +128,7 @@ class CFG(object):
             '604800',
         ))
 
+        self.DEBUG = asbool(settings.get('debug', False))
         # TODO - G.M - 27-03-2018 - [Email] Restore email config
         ###
         # EMAIL related stuff (notification, reply)

--- a/tracim/tests/functional/test_session.py
+++ b/tracim/tests/functional/test_session.py
@@ -17,8 +17,6 @@ class TestLogoutEndpoint(FunctionalTest):
 
 class TestLoginEndpointUnititedDB(FunctionalTestNoDB):
 
-    @pytest.mark.xfail(raises=OperationalError,
-                       reason='Not supported yet by hapic')
     def test_api__try_login_enpoint__err_500__no_inited_db(self):
         params = {
             'email': 'admin@admin.admin',


### PR DESCRIPTION
need https://github.com/algoo/hapic/pull/49 (probably in hapic 0.40)
closes #59 

Add support for NotFound and Operational Error (Sqlalchemy) Exception by hapic for all requests.
Those error as not as clear as it should be, we need to fix this later, see #76